### PR TITLE
Add support for upstream subdirectories

### DIFF
--- a/build/git-cockpit.js
+++ b/build/git-cockpit.js
@@ -287,13 +287,26 @@ const _GIT_COCKPIT = {
 		}
 
 		names.forEach(name => {
-
 			_fs.readdirSync(path + '/refs/remotes/' + name)
 				// .filter(ref => ref !== 'HEAD')
-				.map(ref => [
-					ref,
-					_fs.readFileSync(path + '/refs/remotes/' + name + '/' + ref).toString('utf8').trim()
-				])
+				.reduce((refs, ref) => {
+					let refPath = path + '/refs/remotes/' + name + '/' + ref;
+					let isDirectory = _fs.lstatSync(refPath).isDirectory();
+					if (!isDirectory) {
+						refs.push([
+							ref,
+							_fs.readFileSync(refPath).toString('utf8').trim()
+						]);
+					} else {
+						let subdirRefs = _fs.readdirSync(refPath)
+							.map(ref => [
+								ref,
+								_fs.readFileSync(refPath + '/' + ref).toString('utf8').trim()
+							]);
+						refs.push.apply(refs, subdirRefs);
+					}
+					return refs;
+				}, [])
 				.forEach(ref => {
 
 					remotes.push({

--- a/design/index.js
+++ b/design/index.js
@@ -212,7 +212,7 @@ if (typeof Array.prototype.unique !== 'function') {
 
 		});
 
-	}
+	};
 
 
 


### PR DESCRIPTION
Some of my repos have subdirectories inside the upstream folder e.g:
```
githunt-schema
helfer-patch-4
receiving_updates
greenkeeper/hexo-renderer-ejs-0.3.0
greenkeeper/hexo-renderer-marked-0.3.0
```
The program crashed because it expects those subdirectories to be files. I added a directory check which scans the subdirectories.